### PR TITLE
Fix: Grouped Items not being reflected under the Manage Group Section

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,6 +5,7 @@
   "description": "Organize and manage your browser tabs efficiently.",
   "permissions": [
     "tabs",
+    "tabGroups",
     "storage",
     "activeTab",
     "scripting"


### PR DESCRIPTION

This PR fixes an issue where the extension was throwing a TypeError due to missing permissions for the chrome.tabGroups API. The error occurred because chrome.tabGroups was undefined when accessed.

Changes Made
Added "tabGroups" to the "permissions" array in manifest.json to enable the use of the chrome.tabGroups API.

Why This is Needed
Without explicitly declaring "tabGroups" in the permissions, the Chrome extension environment does not expose the API, resulting in runtime errors when attempting to call chrome.tabGroups.update(...).